### PR TITLE
fix: .gitignoreのタイポ修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage/
 .env.production.local
 
 # IDE files
-.calude/
+.claude/
 .vscode/
 .idea/
 *.swp


### PR DESCRIPTION
## 概要
.gitignoreファイル内の.claudeディレクトリ指定でタイポを修正しました。

## 変更内容
- `.calude/` → `.claude/` に修正
- IDEファイルの除外設定が正しく動作するようになります

## 修正理由
- Claude Code用の設定ディレクトリが適切に除外されていなかった
- タイポにより.claudeディレクトリがバージョン管理に含まれる可能性があった

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>